### PR TITLE
feat(web): add advanced drawing tools (Phase 2.12)

### DIFF
--- a/lib/scrawly_web/components/drawing_canvas.ex
+++ b/lib/scrawly_web/components/drawing_canvas.ex
@@ -1,65 +1,38 @@
 defmodule ScrawlyWeb.Components.DrawingCanvas do
+  @moduledoc "SVG drawing canvas supporting multi-stroke rendering with color and width."
   use Hologram.Component
 
   prop :room_id, :string, default: "test"
   prop :is_drawer, :boolean, default: false
   prop :disabled, :boolean, default: false
-  prop :path, :string, default: ""
-  prop :drawing?, :boolean, default: false
-
-  def init(params, component, _server) do
-    put_state(component, params)
-  end
-
-  def action(:clear_canvas, _params, component) do
-    put_state(component, drawing?: false, path: "")
-  end
-
-  def action(:draw_move, params, %{state: %{drawing?: true}} = component) do
-    new_path = component.state.path <> " L #{params.event.offset_x} #{params.event.offset_y}"
-    put_state(component, :path, new_path)
-  end
-
-  def action(:draw_move, _params, component) do
-    component
-  end
-
-  def action(:start_drawing, params, component) do
-    new_path =
-      if component.state.path == "" do
-        "M #{params.event.offset_x} #{params.event.offset_y}"
-      else
-        component.state.path <> " M #{params.event.offset_x} #{params.event.offset_y}"
-      end
-
-    put_state(component, drawing?: true, path: new_path)
-  end
-
-  def action(:stop_drawing, _params, component) do
-    put_state(component, :drawing?, false)
-  end
+  prop :strokes, :list, default: []
+  prop :active_color, :string, default: "#000000"
+  prop :active_width, :integer, default: 2
 
   def template do
     ~HOLO"""
-    <div class="space-y-4">
-      <div class="flex items-center justify-between">
-        <h3 class="text-lg font-semibold">Drawing Canvas</h3>
-        <button
-          $show={@is_drawer && !@disabled}
-          $click={action: :clear_canvas, target: "drawing_canvas"}
-          class="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded disabled:opacity-50">
-          Clear
-        </button>
-      </div>
+    <div class="canvas-frame">
       <svg
-        class="bg-white border border-gray-300 rounded w-full h-96"
+        viewBox="0 0 800 450"
+        preserveAspectRatio="xMidYMid meet"
         style="touch-action: none;"
-      $pointer_down={action: :start_drawing, target: "drawing_canvas"}
-    $pointer_move={action: :draw_move, target: "drawing_canvas"}
-    $pointer_up={action: :stop_drawing, target: "drawing_canvas"}
-    $pointer_cancel={action: :stop_drawing, target: "drawing_canvas"}
+        $pointer_down={:canvas_pointer_down}
+        $pointer_move={:canvas_pointer_move}
+        $pointer_up={:canvas_pointer_up}
+        $pointer_cancel={:canvas_pointer_up}
       >
-        <path d={@path} stroke="#2563eb" stroke-width="2" fill="none" />
+        <defs>
+          <pattern id="canvas-grid" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+            <circle cx="1" cy="1" r="0.5" fill="rgba(0,0,0,0.05)" />
+          </pattern>
+        </defs>
+        <rect width="800" height="450" fill="url(#canvas-grid)" />
+        {%for stroke <- @strokes}
+          <path d={stroke.path} stroke={stroke.color} stroke-width={stroke.width} fill="none" stroke-linecap="round" stroke-linejoin="round" />
+        {/for}
+        {%if @is_drawer}
+          <path id="drawing-path" stroke={@active_color} stroke-width={@active_width} fill="none" stroke-linecap="round" stroke-linejoin="round" />
+        {/if}
       </svg>
     </div>
     """

--- a/lib/scrawly_web/pages/drawing_manager.mjs
+++ b/lib/scrawly_web/pages/drawing_manager.mjs
@@ -1,0 +1,159 @@
+// JS-managed SVG drawing — bypasses Hologram re-renders for smooth drawing.
+// Supports color, width, stroke history, and undo.
+
+var currentColor = "#000000";
+var currentWidth = 2;
+var strokeHistory = []; // completed strokes: [{path, color, width}, ...]
+var currentStrokePath = ""; // path being drawn right now
+
+function getPathEl() {
+  return document.getElementById("drawing-path");
+}
+
+function setActivePathD(d) {
+  var el = getPathEl();
+  if (el) {
+    el.setAttribute("d", d);
+    el.setAttribute("stroke", currentColor);
+    el.setAttribute("stroke-width", currentWidth);
+  }
+}
+
+function renderCompletedStrokes() {
+  // Render completed strokes as separate path elements in the SVG
+  var svg = getPathEl() ? getPathEl().closest("svg") : null;
+  if (!svg) return;
+
+  // Remove old completed stroke elements (marked with data-completed)
+  var old = svg.querySelectorAll("[data-completed]");
+  for (var i = 0; i < old.length; i++) {
+    old[i].remove();
+  }
+
+  // Insert completed strokes before the active path element
+  var activePath = getPathEl();
+  for (var j = 0; j < strokeHistory.length; j++) {
+    var s = strokeHistory[j];
+    var p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p.setAttribute("d", s.path);
+    p.setAttribute("stroke", s.color);
+    p.setAttribute("stroke-width", s.width);
+    p.setAttribute("fill", "none");
+    p.setAttribute("stroke-linecap", "round");
+    p.setAttribute("stroke-linejoin", "round");
+    p.setAttribute("data-completed", "true");
+    if (activePath) {
+      svg.insertBefore(p, activePath);
+    } else {
+      svg.appendChild(p);
+    }
+  }
+}
+
+// Called on pointer_down — begin a new stroke
+export function startStroke(x, y) {
+  currentStrokePath = "M " + x + " " + y;
+  setActivePathD(currentStrokePath);
+}
+
+// Called on pointer_move — extend the current stroke
+export function continueStroke(x, y) {
+  currentStrokePath += " L " + x + " " + y;
+  setActivePathD(currentStrokePath);
+}
+
+// Called on pointer_up — complete the stroke, send to server, return path
+export function endStroke() {
+  if (currentStrokePath) {
+    var stroke = { path: currentStrokePath, color: currentColor, width: currentWidth };
+    strokeHistory.push(stroke);
+
+    // Send completed stroke to server via channel
+    var gs = window.gameSocket;
+    if (gs && gs.isInRoom()) {
+      if (gs.sendDrawingStroke) {
+        gs.sendDrawingStroke(currentStrokePath, currentColor, currentWidth);
+      } else {
+        gs.sendDrawingSegment(currentStrokePath);
+      }
+    }
+
+    // Render completed strokes and clear active path
+    renderCompletedStrokes();
+    currentStrokePath = "";
+    setActivePathD("");
+  }
+  return currentStrokePath;
+}
+
+// Called on clear
+export function clearDrawing() {
+  strokeHistory = [];
+  currentStrokePath = "";
+  setActivePathD("");
+  renderCompletedStrokes();
+  var gs = window.gameSocket;
+  if (gs && gs.isInRoom()) {
+    gs.sendDrawingClear();
+  }
+}
+
+// Set strokes from server (late joiner sync, undo sync)
+export function setStrokes(strokes) {
+  strokeHistory = (strokes || []).map(function(s) {
+    return { path: s.path || "", color: s.color || "#000000", width: s.width || 2 };
+  });
+  currentStrokePath = "";
+  renderCompletedStrokes();
+  setActivePathD("");
+}
+
+// Set the full path (legacy compat / non-drawer sync)
+export function setDrawingPath(path) {
+  if (!path || path === "") {
+    strokeHistory = [];
+    currentStrokePath = "";
+    renderCompletedStrokes();
+    setActivePathD("");
+  }
+}
+
+// Return current path string (legacy compat)
+export function getDrawingPath() {
+  var parts = strokeHistory.map(function(s) { return s.path; });
+  if (currentStrokePath) parts.push(currentStrokePath);
+  return parts.join(" ");
+}
+
+// Reset sent tracking (legacy compat)
+export function resetSentLength() {
+  // No longer needed with stroke-based model
+}
+
+// Tool state setters — called from Hologram actions
+export function setToolColor(color) {
+  currentColor = color;
+  var el = getPathEl();
+  if (el) el.setAttribute("stroke", color);
+}
+
+export function setToolWidth(width) {
+  currentWidth = width;
+  var el = getPathEl();
+  if (el) el.setAttribute("stroke-width", width);
+}
+
+// Undo last stroke — removes from history, sends undo to server
+export function undoStroke() {
+  if (strokeHistory.length > 0) {
+    strokeHistory.pop();
+    renderCompletedStrokes();
+    currentStrokePath = "";
+    setActivePathD("");
+
+    var gs = window.gameSocket;
+    if (gs && gs.isInRoom() && gs.sendDrawingUndo) {
+      gs.sendDrawingUndo();
+    }
+  }
+}

--- a/test/scrawly_web/channels/game_channel_drawing_test.exs
+++ b/test/scrawly_web/channels/game_channel_drawing_test.exs
@@ -4,9 +4,9 @@ defmodule ScrawlyWeb.GameChannelDrawingTest do
   alias ScrawlyWeb.GameChannel
   alias Scrawly.Accounts
   alias Scrawly.Games
+  alias Scrawly.Games.RoomServer
 
   setup do
-    # Create a test user
     {:ok, user} =
       Accounts.User
       |> Ash.Changeset.for_create(:create, %{
@@ -14,67 +14,160 @@ defmodule ScrawlyWeb.GameChannelDrawingTest do
       })
       |> Ash.create(authorize?: false)
 
-    # Create a test room
-    {:ok, room} =
-      Games.Room
-      |> Ash.Changeset.for_create(:create, %{
-        code: "TEST#{:rand.uniform(1000)}",
-        max_players: 8
-      })
-      |> Ash.create()
-
-    # Create a valid token for the user
+    {:ok, room} = Games.create_room(%{name: "Test Room", max_players: 8, creator_id: user.id})
+    {:ok, _pid} = RoomServer.ensure_started(room.id)
     {:ok, token, _claims} = AshAuthentication.Jwt.token_for_user(user)
-
     {:ok, socket} = connect(ScrawlyWeb.UserSocket, %{"token" => token})
 
     %{socket: socket, user: user, room: room}
   end
 
-  describe "drawing events" do
-    test "handles drawing_start event", %{socket: socket, room: room} do
+  describe "drawing_stroke (new format)" do
+    test "broadcasts stroke with color and width", %{socket: socket, room: room} do
       {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
 
-      ref = push(socket, "drawing_start", %{"x" => 100, "y" => 150})
-      assert_reply ref, :ok, %{status: "drawing_started"}
+      ref =
+        push(socket, "drawing_stroke", %{
+          "segment" => "M 10 20 L 30 40",
+          "color" => "#EF4444",
+          "width" => 5
+        })
 
-      assert_broadcast "drawing_start", %{
-        "x" => 100,
-        "y" => 150,
-        "player_id" => _player_id
+      assert_reply ref, :ok, %{status: "stroke_received"}
+
+      assert_broadcast "drawing_stroke", %{
+        "path" => "M 10 20 L 30 40",
+        "color" => "#EF4444",
+        "width" => 5
       }
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert length(state.drawing_strokes) == 1
+      [stroke] = state.drawing_strokes
+      assert stroke.path == "M 10 20 L 30 40"
+      assert stroke.color == "#EF4444"
+      assert stroke.width == 5
     end
 
-    test "handles drawing_move event", %{socket: socket, room: room} do
+    test "defaults color and width when not provided", %{socket: socket, room: room} do
       {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
 
-      ref = push(socket, "drawing_move", %{"x" => 120, "y" => 160})
-      assert_reply ref, :ok, %{status: "drawing_moved"}
+      ref = push(socket, "drawing_stroke", %{"segment" => "M 10 20"})
+      assert_reply ref, :ok, %{status: "stroke_received"}
 
-      assert_broadcast "drawing_move", %{
-        "x" => 120,
-        "y" => 160,
-        "player_id" => _player_id
-      }
+      {:ok, state} = RoomServer.get_state(room.id)
+      [stroke] = state.drawing_strokes
+      assert stroke.color == "#000000"
+      assert stroke.width == 2
     end
 
-    test "handles drawing_stop event", %{socket: socket, room: room} do
+    test "rejects empty strokes", %{socket: socket, room: room} do
       {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
 
-      ref = push(socket, "drawing_stop", %{})
-      assert_reply ref, :ok, %{status: "drawing_stopped"}
+      ref = push(socket, "drawing_stroke", %{"segment" => ""})
+      assert_reply ref, :error, %{reason: "empty_segment"}
+    end
+  end
 
-      assert_broadcast "drawing_stop", %{
-        "player_id" => _player_id
+  describe "drawing_segment (legacy backward compat)" do
+    test "converts to stroke with default color/width", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      ref = push(socket, "drawing_segment", %{"segment" => "M 10 20 L 30 40"})
+      assert_reply ref, :ok, %{status: "segment_received"}
+
+      # Broadcasts as new stroke format
+      assert_broadcast "drawing_stroke", %{
+        "path" => "M 10 20 L 30 40",
+        "color" => "#000000",
+        "width" => 2
       }
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert length(state.drawing_strokes) == 1
+      [stroke] = state.drawing_strokes
+      assert stroke.path == "M 10 20 L 30 40"
+      assert stroke.color == "#000000"
     end
 
-    test "drawing events are not sent to the drawer", %{socket: socket, room: room} do
+    test "rejects empty segments", %{socket: socket, room: room} do
       {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
 
-      # The drawer should not receive their own drawing events (broadcast_from)
-      push(socket, "drawing_start", %{"x" => 100, "y" => 150})
-      refute_push "drawing_start", %{}
+      ref = push(socket, "drawing_segment", %{"segment" => ""})
+      assert_reply ref, :error, %{reason: "empty_segment"}
+    end
+  end
+
+  describe "drawing_clear" do
+    test "broadcasts clear and resets strokes", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      # Add a stroke first
+      push(socket, "drawing_stroke", %{"segment" => "M 10 20", "color" => "#000000", "width" => 2})
+
+      Process.sleep(50)
+
+      ref = push(socket, "drawing_clear", %{})
+      assert_reply ref, :ok, %{status: "drawing_cleared"}
+      assert_broadcast "drawing_clear", %{}
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert state.drawing_strokes == []
+    end
+  end
+
+  describe "drawing_undo" do
+    test "removes last stroke and broadcasts updated strokes", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      # Add two strokes
+      push(socket, "drawing_stroke", %{"segment" => "M 10 20", "color" => "#000000", "width" => 2})
+
+      Process.sleep(20)
+
+      push(socket, "drawing_stroke", %{"segment" => "M 30 40", "color" => "#EF4444", "width" => 5})
+
+      Process.sleep(20)
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert length(state.drawing_strokes) == 2
+
+      ref = push(socket, "drawing_undo", %{})
+      assert_reply ref, :ok, %{status: "undo_done"}
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert length(state.drawing_strokes) == 1
+      [stroke] = state.drawing_strokes
+      assert stroke.path == "M 10 20"
+    end
+
+    test "undo on empty strokes is a noop", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      ref = push(socket, "drawing_undo", %{})
+      assert_reply ref, :ok, _
+
+      {:ok, state} = RoomServer.get_state(room.id)
+      assert state.drawing_strokes == []
+    end
+  end
+
+  describe "get_drawing_path (now returns strokes)" do
+    test "returns strokes array from RoomServer", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      RoomServer.append_drawing(room.id, %{path: "M 100 200", color: "#3B82F6", width: 10})
+
+      ref = push(socket, "get_drawing_path", %{})
+      assert_reply ref, :ok, %{strokes: strokes}
+      assert length(strokes) == 1
+    end
+
+    test "returns empty strokes when no drawing exists", %{socket: socket, room: room} do
+      {:ok, _, socket} = subscribe_and_join(socket, GameChannel, "game:#{room.code}")
+
+      ref = push(socket, "get_drawing_path", %{})
+      assert_reply ref, :ok, %{strokes: []}
     end
   end
 end

--- a/test/scrawly_web/components/drawing_canvas_test.exs
+++ b/test/scrawly_web/components/drawing_canvas_test.exs
@@ -1,65 +1,186 @@
 defmodule ScrawlyWeb.Components.DrawingCanvasTest do
+  @moduledoc """
+  Tests for drawing actions on GamePage including tool selection,
+  multi-stroke state, and undo.
+  """
   use ExUnit.Case, async: true
 
-  alias ScrawlyWeb.Components.DrawingCanvas
+  alias ScrawlyWeb.Pages.GamePage
 
-  describe "init/3" do
-    test "initializes with empty drawing state" do
-      component = %{state: %{}}
-      result = DrawingCanvas.init(%{drawing?: false, path: ""}, component, nil)
+  defp drawing_component(overrides \\ %{}) do
+    defaults = %{
+      drawing_strokes: [],
+      drawing?: false,
+      draw_color: "#000000",
+      draw_width: 2,
+      draw_eraser: false,
+      is_drawer: true,
+      game_started: true,
+      time_left: 60,
+      room_id: "test-room"
+    }
+
+    %Hologram.Component{state: Map.merge(defaults, overrides)}
+  end
+
+  describe "canvas_pointer_down" do
+    test "starts drawing for drawer" do
+      comp = drawing_component()
+      params = %{event: %{offset_x: 100, offset_y: 150}}
+
+      result = GamePage.action(:canvas_pointer_down, params, comp)
+
+      assert result.state.drawing? == true
+    end
+
+    test "does nothing for non-drawer" do
+      comp = drawing_component(%{is_drawer: false})
+      params = %{event: %{offset_x: 100, offset_y: 150}}
+
+      result = GamePage.action(:canvas_pointer_down, params, comp)
 
       assert result.state.drawing? == false
-      assert result.state.path == ""
+    end
+
+    test "does nothing when time is 0" do
+      comp = drawing_component(%{time_left: 0})
+      params = %{event: %{offset_x: 100, offset_y: 150}}
+
+      result = GamePage.action(:canvas_pointer_down, params, comp)
+
+      assert result.state.drawing? == false
     end
   end
 
-  describe "actions" do
-    test "start_drawing begins drawing and adds move command to path" do
-      component = %{state: %{drawing?: false, path: ""}}
-      params = %{event: %{offset_x: 100, offset_y: 150}}
-
-      result = DrawingCanvas.action(:start_drawing, params, component)
-
-      assert result.state.drawing? == true
-      assert result.state.path == "M 100 150"
-    end
-
-    test "draw_move adds line command when drawing" do
-      component = %{state: %{drawing?: true, path: "M 100 150"}}
+  describe "canvas_pointer_move" do
+    test "does not update Hologram state (drawing managed by JS)" do
+      comp = drawing_component(%{drawing?: true})
       params = %{event: %{offset_x: 120, offset_y: 160}}
 
-      result = DrawingCanvas.action(:draw_move, params, component)
+      result = GamePage.action(:canvas_pointer_move, params, comp)
 
-      assert result.state.drawing? == true
-      assert result.state.path == "M 100 150 L 120 160"
+      # Strokes unchanged — JS handles SVG directly
+      assert result.state.drawing_strokes == []
     end
 
-    test "draw_move does nothing when not drawing" do
-      component = %{state: %{drawing?: false, path: "M 100 150"}}
+    test "does nothing when not drawing" do
+      comp = drawing_component(%{drawing?: false})
       params = %{event: %{offset_x: 120, offset_y: 160}}
 
-      result = DrawingCanvas.action(:draw_move, params, component)
+      result = GamePage.action(:canvas_pointer_move, params, comp)
+
+      assert result.state.drawing_strokes == []
+    end
+  end
+
+  describe "canvas_pointer_up" do
+    test "stops drawing" do
+      comp = drawing_component(%{drawing?: true})
+
+      result = GamePage.action(:canvas_pointer_up, %{}, comp)
 
       assert result.state.drawing? == false
-      assert result.state.path == "M 100 150"
+    end
+  end
+
+  describe "clear_canvas" do
+    test "resets strokes to empty" do
+      strokes = [%{path: "M 100 150 L 120 160", color: "#000000", width: 2}]
+      comp = drawing_component(%{drawing_strokes: strokes})
+
+      result = GamePage.action(:clear_canvas, %{}, comp)
+
+      assert result.state.drawing_strokes == []
+    end
+  end
+
+  describe "receive_drawing_stroke" do
+    test "appends stroke to non-drawer's strokes" do
+      comp = drawing_component(%{is_drawer: false})
+      params = %{path: "M 10 20 L 30 40", color: "#EF4444", width: 5}
+
+      result = GamePage.action(:receive_drawing_stroke, params, comp)
+
+      assert length(result.state.drawing_strokes) == 1
+      [stroke] = result.state.drawing_strokes
+      assert stroke.path == "M 10 20 L 30 40"
+      assert stroke.color == "#EF4444"
+      assert stroke.width == 5
     end
 
-    test "stop_drawing ends drawing state" do
-      component = %{state: %{drawing?: true, path: "M 100 150 L 120 160"}}
+    test "does nothing for drawer" do
+      comp = drawing_component(%{is_drawer: true})
+      params = %{path: "M 10 20", color: "#000000", width: 2}
 
-      result = DrawingCanvas.action(:stop_drawing, %{}, component)
+      result = GamePage.action(:receive_drawing_stroke, params, comp)
 
-      assert result.state.drawing? == false
-      assert result.state.path == "M 100 150 L 120 160"
+      assert result.state.drawing_strokes == []
     end
 
-    test "clear_canvas resets drawing state and path" do
-      component = %{state: %{drawing?: true, path: "M 100 150 L 120 160"}}
+    test "accumulates multiple strokes" do
+      comp =
+        drawing_component(%{
+          is_drawer: false,
+          drawing_strokes: [
+            %{path: "M 1 2", color: "#000000", width: 2}
+          ]
+        })
 
-      result = DrawingCanvas.action(:clear_canvas, %{}, component)
+      params = %{path: "M 10 20", color: "#3B82F6", width: 10}
 
-      assert result.state.drawing? == false
-      assert result.state.path == ""
+      result = GamePage.action(:receive_drawing_stroke, params, comp)
+
+      assert length(result.state.drawing_strokes) == 2
+    end
+  end
+
+  describe "receive_drawing_clear" do
+    test "clears all strokes" do
+      comp =
+        drawing_component(%{
+          drawing_strokes: [
+            %{path: "M 1 2", color: "#000000", width: 2}
+          ]
+        })
+
+      result = GamePage.action(:receive_drawing_clear, %{}, comp)
+
+      assert result.state.drawing_strokes == []
+    end
+  end
+
+  describe "tool selection actions" do
+    test "select_color updates draw_color and disables eraser" do
+      comp = drawing_component(%{draw_eraser: true, draw_color: "#000000"})
+
+      result = GamePage.action(:select_color, %{color: "#EF4444"}, comp)
+
+      assert result.state.draw_color == "#EF4444"
+      assert result.state.draw_eraser == false
+    end
+
+    test "select_width updates draw_width" do
+      comp = drawing_component(%{draw_width: 2})
+
+      result = GamePage.action(:select_width, %{width: 10}, comp)
+
+      assert result.state.draw_width == 10
+    end
+
+    test "toggle_eraser enables eraser" do
+      comp = drawing_component(%{draw_eraser: false})
+
+      result = GamePage.action(:toggle_eraser, %{}, comp)
+
+      assert result.state.draw_eraser == true
+    end
+
+    test "toggle_eraser disables eraser on second toggle" do
+      comp = drawing_component(%{draw_eraser: true})
+
+      result = GamePage.action(:toggle_eraser, %{}, comp)
+
+      assert result.state.draw_eraser == false
     end
   end
 end


### PR DESCRIPTION
Enhance DrawingCanvas with 8-color palette, three brush sizes, eraser tool, and stroke-level undo synced via channel. Add inline toolbar with tool state persistence in page state. Includes drawing_manager.mjs for client-side state and updated tests.