### PR TITLE
feat(web): add demo board and navbar painter

### DIFF
--- a/lib/scrawly/games/demo_board_server.ex
+++ b/lib/scrawly/games/demo_board_server.ex
@@ -1,0 +1,49 @@
+defmodule Scrawly.Games.DemoBoardServer do
+  @moduledoc """
+  Single shared canvas for the home page. Holds an ordered list of completed
+  strokes in memory. State changes are broadcast over the `demo:board` PubSub
+  topic so every connected client stays in sync.
+  """
+  use GenServer
+
+  @topic "demo:board"
+  @max_strokes 500
+
+  # ── Client API ─────────────────────────────────────────────────────
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @doc "Return the current list of strokes."
+  def get_strokes, do: GenServer.call(__MODULE__, :get_strokes)
+
+  @doc "Append a stroke and broadcast it to subscribers."
+  def add_stroke(%{path: _, color: _, width: _} = stroke),
+    do: GenServer.cast(__MODULE__, {:add_stroke, stroke})
+
+  @doc "Clear the board and broadcast the change."
+  def clear, do: GenServer.cast(__MODULE__, :clear)
+
+  def topic, do: @topic
+
+  # ── Server callbacks ───────────────────────────────────────────────
+
+  @impl true
+  def init(_), do: {:ok, %{strokes: []}}
+
+  @impl true
+  def handle_call(:get_strokes, _from, state), do: {:reply, state.strokes, state}
+
+  @impl true
+  def handle_cast({:add_stroke, stroke}, state) do
+    strokes = Enum.take(state.strokes ++ [stroke], -@max_strokes)
+    Phoenix.PubSub.broadcast(Scrawly.PubSub, @topic, {:stroke_added, stroke})
+    {:noreply, %{state | strokes: strokes}}
+  end
+
+  def handle_cast(:clear, state) do
+    Phoenix.PubSub.broadcast(Scrawly.PubSub, @topic, :strokes_cleared)
+    {:noreply, %{state | strokes: []}}
+  end
+end

--- a/lib/scrawly_web/channels/demo_board_channel.ex
+++ b/lib/scrawly_web/channels/demo_board_channel.ex
@@ -1,0 +1,60 @@
+defmodule ScrawlyWeb.DemoBoardChannel do
+  @moduledoc """
+  Real-time channel for the shared demo canvas on the home page.
+  Topic: `demo:board`.
+
+  Inbound events:
+    * `"draw"` (`%{path, color, width}`) — append a completed stroke
+    * `"clear"` — wipe the board
+
+  Outbound events:
+    * `"strokes"` — full snapshot on join (and after clear)
+    * `"stroke"` — single newly added stroke
+    * `"cleared"` — board was wiped
+  """
+  use ScrawlyWeb, :channel
+
+  alias Scrawly.Games.DemoBoardServer
+
+  @impl true
+  def join("demo:board", _payload, socket) do
+    send(self(), :after_join)
+    Phoenix.PubSub.subscribe(Scrawly.PubSub, DemoBoardServer.topic())
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info(:after_join, socket) do
+    push(socket, "strokes", %{strokes: DemoBoardServer.get_strokes()})
+    {:noreply, socket}
+  end
+
+  def handle_info({:stroke_added, stroke}, socket) do
+    push(socket, "stroke", stroke)
+    {:noreply, socket}
+  end
+
+  def handle_info(:strokes_cleared, socket) do
+    push(socket, "cleared", %{})
+    {:noreply, socket}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_in("draw", %{"path" => path, "color" => color, "width" => width}, socket)
+      when is_binary(path) and is_binary(color) and is_integer(width) do
+    if String.length(path) > 0 and String.length(path) < 8_000 do
+      DemoBoardServer.add_stroke(%{path: path, color: color, width: width})
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_in("clear", _payload, socket) do
+    DemoBoardServer.clear()
+    {:noreply, socket}
+  end
+
+  def handle_in(_event, _payload, socket), do: {:noreply, socket}
+end

--- a/lib/scrawly_web/components/game_demo.ex
+++ b/lib/scrawly_web/components/game_demo.ex
@@ -1,0 +1,91 @@
+defmodule ScrawlyWeb.Components.GameDemo do
+  @moduledoc """
+  Shared interactive canvas rendered on the home page. All drawing flows over
+  the `demo:board` Phoenix channel — every connected visitor sees and edits the
+  same board in real time. Strokes are committed to the DOM directly by
+  `demo_board.mjs` so Hologram never re-renders per pointer move.
+  """
+  use Hologram.Component
+
+  prop :color, :string, default: "#000000"
+  prop :width, :integer, default: 2
+  prop :eraser, :boolean, default: false
+
+  @palette [
+    "#000000",
+    "#EF4444",
+    "#F97316",
+    "#EAB308",
+    "#22C55E",
+    "#3B82F6",
+    "#A855F7",
+    "#EC4899"
+  ]
+  @widths [2, 4, 8]
+
+  def template do
+    ~HOLO"""
+    <div class="surface" style="overflow: hidden; display: flex; flex-direction: column;">
+      <div class="between" style="padding: 12px 14px; border-bottom: 1px solid var(--hairline);">
+        <div class="row" style="gap: 10px;">
+          <span class="chip chip-live">live demo</span>
+          <span class="section-label">shared board · everyone draws together</span>
+        </div>
+        <button type="button" class="app-btn app-btn-ghost app-btn-sm" $click={:demo_clear}>clear</button>
+      </div>
+
+      <div class="demo-canvas" style="aspect-ratio: 16/9; min-height: 220px; position: relative;">
+        <svg
+          id="demo-board-svg"
+          viewBox="0 0 400 320"
+          preserveAspectRatio="xMidYMid meet"
+          style="touch-action: none; width: 100%; height: 100%;"
+          $pointer_down={:demo_pointer_down}
+          $pointer_move={:demo_pointer_move}
+          $pointer_up={:demo_pointer_up}
+          $pointer_cancel={:demo_pointer_up}>
+          <defs>
+            <pattern id="demo-board-dotgrid" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse">
+              <circle cx="1" cy="1" r="0.6" fill="rgba(0,0,0,0.06)" />
+            </pattern>
+          </defs>
+          <rect width="400" height="320" fill="url(#demo-board-dotgrid)" />
+          <path id="demo-board-active-path" d="" stroke={@color} stroke-width={@width} fill="none" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </div>
+
+      <div class="between" style="padding: 10px 14px; gap: 12px; flex-wrap: wrap;">
+        <div class="row" style="gap: 4px;">
+          {%for c <- ["#000000", "#EF4444", "#F97316", "#EAB308", "#22C55E", "#3B82F6", "#A855F7", "#EC4899"]}
+            <button
+              type="button"
+              class={"swatch " <> if(@color == c and !@eraser, do: "active", else: "")}
+              style={"background: " <> c <> ";"}
+              $click={:demo_set_color, value: c}></button>
+          {/for}
+        </div>
+
+        <div class="row" style="gap: 4px;">
+          {%for {wv, lbl} <- [{2, "s"}, {4, "m"}, {8, "l"}]}
+            <button
+              type="button"
+              class={"tool-btn " <> if(@width == wv and !@eraser, do: "active", else: "")}
+              $click={:demo_set_width, value: wv}>
+              <span class="size-dot" style={"width: " <> Integer.to_string(wv * 2) <> "px; height: " <> Integer.to_string(wv * 2) <> "px;"}></span>
+              <span class="mono" style="font-size: 11px; color: var(--muted); margin-left: 4px;">{lbl}</span>
+            </button>
+          {/for}
+        </div>
+
+        <button
+          type="button"
+          class={"tool-btn " <> if(@eraser, do: "active", else: "")}
+          $click={:demo_toggle_eraser}>erase</button>
+      </div>
+    </div>
+    """
+  end
+
+  def palette, do: @palette
+  def widths, do: @widths
+end

--- a/lib/scrawly_web/components/navbar_painter.ex
+++ b/lib/scrawly_web/components/navbar_painter.ex
@@ -1,0 +1,19 @@
+defmodule ScrawlyWeb.Components.NavbarPainter do
+  @moduledoc """
+  Stateless component that renders colored strokes in the navbar background.
+  Animation state is managed by the parent AppLayout.
+  """
+  use Hologram.Component
+
+  prop :strokes, :list, default: []
+
+  def template do
+    ~HOLO"""
+    <div class="absolute inset-0 pointer-events-none overflow-hidden" style="z-index:0">
+      {%for stroke <- @strokes}
+        <div class="absolute left-0 transition-[width] duration-100 ease-linear" style={"bottom:" <> to_string(stroke.y) <> "px;height:14px;width:" <> to_string(stroke.progress) <> "%;background:" <> stroke.color <> ";opacity:0.35"}></div>
+      {/for}
+    </div>
+    """
+  end
+end

--- a/lib/scrawly_web/pages/demo_board.mjs
+++ b/lib/scrawly_web/pages/demo_board.mjs
@@ -1,0 +1,158 @@
+// Bridge between the shared demo canvas SVG and the DemoBoard Phoenix channel.
+// Keeps drawing smooth by mutating SVG paths directly — Hologram only ever sees
+// the full strokes list on snapshot, never per-pixel state.
+
+var socket = null;
+var channel = null;
+var strokes = [];        // completed strokes from the server [{path, color, width}]
+var currentColor = "#000000";
+var currentWidth = 2;
+var currentEraser = false;
+var activePath = "";
+
+const SVG_ID = "demo-board-svg";
+const ACTIVE_PATH_ID = "demo-board-active-path";
+const ERASER_COLOR = "#ffffff";
+const ERASER_WIDTH = 18;
+
+function svg() {
+  return document.getElementById(SVG_ID);
+}
+
+function activePathEl() {
+  return document.getElementById(ACTIVE_PATH_ID);
+}
+
+// Convert screen-pixel offset_x/offset_y (relative to the SVG element) into
+// viewBox coordinates so the path tracks the cursor exactly regardless of
+// the rendered canvas size.
+function toViewBox(x, y) {
+  var el = svg();
+  if (!el) return [x, y];
+  var vb = el.viewBox && el.viewBox.baseVal;
+  if (!vb || !el.clientWidth || !el.clientHeight) return [x, y];
+  var scaleX = vb.width / el.clientWidth;
+  var scaleY = vb.height / el.clientHeight;
+  return [Math.round((x * scaleX + Number.EPSILON) * 10) / 10,
+          Math.round((y * scaleY + Number.EPSILON) * 10) / 10];
+}
+
+function setActivePathD(d, color, width) {
+  var el = activePathEl();
+  if (el) {
+    el.setAttribute("d", d);
+    el.setAttribute("stroke", color);
+    el.setAttribute("stroke-width", width);
+  }
+}
+
+function renderStrokes() {
+  var s = svg();
+  if (!s) return;
+
+  var old = s.querySelectorAll("[data-demo-stroke]");
+  for (var i = 0; i < old.length; i++) old[i].remove();
+
+  var ap = activePathEl();
+  for (var j = 0; j < strokes.length; j++) {
+    var st = strokes[j];
+    var p = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    p.setAttribute("d", st.path);
+    p.setAttribute("stroke", st.color);
+    p.setAttribute("stroke-width", st.width);
+    p.setAttribute("fill", "none");
+    p.setAttribute("stroke-linecap", "round");
+    p.setAttribute("stroke-linejoin", "round");
+    p.setAttribute("data-demo-stroke", "true");
+    if (ap) s.insertBefore(p, ap);
+    else s.appendChild(p);
+  }
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export function connectDemoBoard() {
+  if (channel) return;
+  if (!window.Phoenix || !window.Phoenix.Socket) {
+    console.error("Phoenix.Socket not available for demo board");
+    return;
+  }
+
+  socket = new window.Phoenix.Socket("/socket", { params: { demo: "true" } });
+  socket.connect();
+
+  channel = socket.channel("demo:board", {});
+  channel.on("strokes", function(payload) {
+    strokes = (payload.strokes || []).map(function(s) {
+      return { path: s.path || "", color: s.color || "#000000", width: s.width || 2 };
+    });
+    renderStrokes();
+  });
+  channel.on("stroke", function(stroke) {
+    strokes.push({ path: stroke.path, color: stroke.color, width: stroke.width });
+    renderStrokes();
+  });
+  channel.on("cleared", function() {
+    strokes = [];
+    renderStrokes();
+    setActivePathD("", currentColor, currentWidth);
+    activePath = "";
+  });
+  channel.join().receive("error", function(resp) {
+    console.error("Failed to join demo:board channel:", resp);
+    channel = null;
+  });
+}
+
+export function disconnectDemoBoard() {
+  if (channel) { channel.leave(); channel = null; }
+  if (socket) { socket.disconnect(); socket = null; }
+  strokes = [];
+}
+
+export function startStroke(x, y) {
+  var p = toViewBox(x, y);
+  activePath = "M " + p[0] + " " + p[1];
+  var c = currentEraser ? ERASER_COLOR : currentColor;
+  var w = currentEraser ? ERASER_WIDTH : currentWidth;
+  setActivePathD(activePath, c, w);
+}
+
+export function continueStroke(x, y) {
+  if (!activePath) return;
+  var p = toViewBox(x, y);
+  activePath += " L " + p[0] + " " + p[1];
+  var c = currentEraser ? ERASER_COLOR : currentColor;
+  var w = currentEraser ? ERASER_WIDTH : currentWidth;
+  setActivePathD(activePath, c, w);
+}
+
+export function endStroke() {
+  if (!activePath) return;
+  var c = currentEraser ? ERASER_COLOR : currentColor;
+  var w = currentEraser ? ERASER_WIDTH : currentWidth;
+
+  if (activePath.length > 5 && channel) {
+    channel.push("draw", { path: activePath, color: c, width: w });
+  }
+  activePath = "";
+  setActivePathD("", c, w);
+}
+
+export function clearBoard() {
+  if (channel) channel.push("clear", {});
+}
+
+export function setColor(color) {
+  currentColor = color;
+  currentEraser = false;
+}
+
+export function setWidth(width) {
+  currentWidth = width;
+  currentEraser = false;
+}
+
+export function setEraser() {
+  currentEraser = true;
+}

--- a/lib/scrawly_web/pages/home_keybinds.mjs
+++ b/lib/scrawly_web/pages/home_keybinds.mjs
@@ -1,0 +1,34 @@
+// Global keyboard shortcuts for the home page.
+// 'N' opens the create-room modal (or the login modal for unauthenticated users).
+
+var handler = null;
+
+export function installHomeKeybinds(authenticated) {
+  uninstallHomeKeybinds();
+
+  handler = function(event) {
+    if (event.key !== "n" && event.key !== "N") return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+    var t = event.target;
+    if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
+
+    if (!globalThis.Hologram || !globalThis.Hologram.dispatchAction) return;
+
+    event.preventDefault();
+    if (authenticated) {
+      globalThis.Hologram.dispatchAction("show_create_room", "page", {});
+    } else {
+      globalThis.Hologram.dispatchAction("show_login", "layout", {});
+    }
+  };
+
+  window.addEventListener("keydown", handler);
+}
+
+export function uninstallHomeKeybinds() {
+  if (handler) {
+    window.removeEventListener("keydown", handler);
+    handler = null;
+  }
+}


### PR DESCRIPTION
Add DemoBoardServer GenServer, demo_board_channel, GameDemo and NavbarPainter components, plus demo_board and home_keybinds client-side mjs handlers. Provides an interactive showcase surface and keyboard shortcuts on the home page.